### PR TITLE
Fix cursor on hover for small-card

### DIFF
--- a/frontend/clientapp/src/app/dashboard/small-cards/small-card/small-card.html
+++ b/frontend/clientapp/src/app/dashboard/small-cards/small-card/small-card.html
@@ -1,6 +1,6 @@
 <div class="card" [ngStyle]="currentStyles">
 
-  <div class="card__header">
+  <div class="card__header" (click)="toggleCollapsed()">
    <!-- matTooltip={{tooltip}} matTooltipClass="headertip"> -->
 
     <div class="card__header-icon {{iconcolor}}">
@@ -8,7 +8,7 @@
     </div>
 
     <div class="card__header-title text-light">
-      <span (click)="toggleCollapsed()"><strong> {{title}} </strong></span>
+      <span><strong> {{title}} </strong></span>
       <i *ngIf="collapsed" class="fa fa-angle-down custom" (click)="toggleCollapsed()" ></i>
       <i *ngIf="!collapsed" class="fa fa-angle-up custom" (click)="toggleCollapsed()"  ></i>
     </div>

--- a/frontend/clientapp/src/app/dashboard/small-cards/small-card/small-card.scss
+++ b/frontend/clientapp/src/app/dashboard/small-cards/small-card/small-card.scss
@@ -37,6 +37,10 @@
     background-color: $color-deep-blue;
     color: $color-white;
 
+    & :hover {
+      cursor: pointer;
+    }
+
     &-icon {
       display: flex;
       align-items: center;


### PR DESCRIPTION
Fix the cursor on hover for the small-card toggle expand collapse.
E.g. Change the cursor on hover for this `Meeting` toggle from `text` to `pointer`.

![image](https://user-images.githubusercontent.com/152131/89123925-65139380-d516-11ea-9374-c1a8ee79ca89.png)
