### PR TITLE
auto create/migrate DB if Development

### DIFF
--- a/src/WebUI/WebApp/Program.cs
+++ b/src/WebUI/WebApp/Program.cs
@@ -1,5 +1,9 @@
 using GM.Application.Configuration;
+using GM.Infrastructure.InfraCore.Data;
+using GM.WebUI.WebApp.Services;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using NLog.Web;
@@ -8,9 +12,30 @@ namespace GM.WebUI.WebApp
 {
     public class Program
     {
+        static IWebHostEnvironment _Env;
+
         public static void Main(string[] args)
         {
             var host = CreateHostBuilder(args).Build();
+
+            // If development, migrate and seed the database.
+            // Migrate() also creates the database if it does not exist.
+            if (_Env.IsDevelopment())
+            {
+                using (var scope = host.Services.CreateScope())
+                {
+                    var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+                    db.Database.Migrate();
+
+                    var seedDatabase = scope.ServiceProvider.GetRequiredService<ISeedDatabase>();
+                    seedDatabase.Seed();
+
+                    // This auth code needs re-work.
+                    //var seedDbUsers = scope.ServiceProvider.GetRequiredService<ISeedAuth>();
+                    //seedDbUsers.Seed();
+                }
+            }
+
             host.Run();
         }
 
@@ -21,8 +46,8 @@ namespace GM.WebUI.WebApp
                 webBuilder.UseStartup<Startup>()
                 .ConfigureAppConfiguration((hostingContext, config) => 
                 {
-                    var env = hostingContext.HostingEnvironment;
-                    BuildConfig.Build(config, env.EnvironmentName);
+                    _Env = hostingContext.HostingEnvironment;
+                    BuildConfig.Build(config, _Env.EnvironmentName);
                 })
                 .ConfigureLogging(logging =>
                 {

--- a/src/WebUI/WebApp/Services/SeedAuth.cs
+++ b/src/WebUI/WebApp/Services/SeedAuth.cs
@@ -11,26 +11,22 @@ using System.Threading.Tasks;
 
 namespace GM.WebUI.WebApp.Services
 {
-    public interface IDbInitializer
+    public interface ISeedAuth
     {
-        //Task Initialize(ApplicationDbContext context, UserManager<ApplicationUser> userManager,
-        //    RoleManager<IdentityRole> roleManager, IConfiguration configuration);
-        Task<bool> Initialize(bool migrateDatabase);
+        Task<bool> Seed();
     }
 
-    // Class to inialize the database with the first admin user. See:
-    // https://stackoverflow.com/questions/40027388/cannot-get-the-usermanager-class/40046290#40046290
-    public class DbInitializer : IDbInitializer
+    public class SeedAuth : ISeedAuth
     {
-        private readonly ILogger<DbInitializer> logger;
+        private readonly ILogger<SeedAuth> logger;
 
-        public DbInitializer(
+        public SeedAuth(
             ApplicationDbContext context,
             UserManager<ApplicationUser> userManager,
             RoleManager<IdentityRole> roleManager,
             //IConfiguration configuration,
             IOptions<AppSettings> config,
-            ILogger<DbInitializer> _logger
+            ILogger<SeedAuth> _logger
             )
         {
             _context = context;
@@ -47,16 +43,8 @@ namespace GM.WebUI.WebApp.Services
         //IConfiguration _configuration;
         private readonly AppSettings _config;
 
-        //public async Task Initialize(ApplicationDbContext context, UserManager<ApplicationUser> userManager,
-        //    RoleManager<IdentityRole> roleManager, IConfiguration configuration)
-        public async Task<bool> Initialize(bool migrateDatabase)
+        public async Task<bool> Seed()
         {
-            // Ensure that the database exists and all pending migrations are applied.
-            if (migrateDatabase)
-            {
-                logger.LogInformation("Migrate Database");
-                _context.Database.Migrate();
-            }
 
             // REMOVED PRIOR CODE 1 - See below
 
@@ -103,19 +91,6 @@ namespace GM.WebUI.WebApp.Services
         }
     }
 
-
-    public class DbInitializer_Stub : IDbInitializer
-    {
-        public DbInitializer_Stub()
-        {
-        }
-
-        public async Task<bool> Initialize(bool migrateDatabase)
-        {
-            await Task.Delay(1);
-            return true;
-        }
-    }
 }
 
 

--- a/src/WebUI/WebApp/Services/SeedDatabase.cs
+++ b/src/WebUI/WebApp/Services/SeedDatabase.cs
@@ -1,7 +1,6 @@
 ﻿using GM.Application.AppCore.Entities.Govbodies;
 using GM.Application.AppCore.Entities.GovLocations;
 using GM.Infrastructure.InfraCore.Data;
-using Microsoft.EntityFrameworkCore;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -165,15 +164,15 @@ namespace GM.WebUI.WebApp.Services
             _context.SaveChanges();
         }
 
-        private ApplicationDbContext GetLocalDbProvider()
-        {
-            string connection = "Server=(localdb)\\mssqllocaldb;Database=Govmeeting;Trusted_Connection=True;MultipleActiveResultSets=true";
-            var optionsBuilder = new DbContextOptionsBuilder<ApplicationDbContext>();
-            optionsBuilder.UseSqlServer(connection);
-            // optionsBuilder.UseInMemoryDatabase(connection)
-            ApplicationDbContext _context = new ApplicationDbContext(null, optionsBuilder.Options);
-            return _context;
-        }
+        //private ApplicationDbContext GetLocalDbProvider()
+        //{
+        //    string connection = "Server=(localdb)\\mssqllocaldb;Database=Govmeeting;Trusted_Connection=True;MultipleActiveResultSets=true";
+        //    var optionsBuilder = new DbContextOptionsBuilder<ApplicationDbContext>();
+        //    optionsBuilder.UseSqlServer(connection);
+        //    // optionsBuilder.UseInMemoryDatabase(connection)
+        //    ApplicationDbContext _context = new ApplicationDbContext(null, optionsBuilder.Options);
+        //    return _context;
+        //}
 
     }
 }

--- a/src/WebUI/WebApp/Startup.cs
+++ b/src/WebUI/WebApp/Startup.cs
@@ -192,7 +192,7 @@ namespace GM.WebUI.WebApp
                 }
             });
 
-            seedDatabase.Seed();
+            //seedDatabase.Seed();
 
         }
 
@@ -251,6 +251,9 @@ namespace GM.WebUI.WebApp
                 o.CallbackPath = "/signin-google"; // Or register the default "/sigin-oidc"
                 o.Scope.Add("email");
             });
+
+            services.AddTransient<ISeedAuth, SeedAuth>();
+
         }
 
         private void ConfigureIdentity(IServiceCollection services)


### PR DESCRIPTION
**Auto create/migrate DB**

Code was added to Program.cs in WebApp to automatically migrate the database, if the environment is Development. The Migrate() call also creates the database if it doesn't exist. This simplifies some of the manual setup during development:

* After a new clone of the code, the database will be created and migrated automatically.
* After a developer makes changes to the DB schema and adds a new migration, other developer will automatically have that migration applied when WebApp is run.

**Move DB init code**

The code for migrating and seeding the DB was moved from Startup.cs to Program.cs in WebApp. Since .Net Core 2.1, it's been recommended to do this. Since 2.1, the Configure method in Startup will be run by the "dotnet ef" commands and there can be a conflict if DB code resides in Configure.